### PR TITLE
update dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,14 +17,7 @@ updates:
     # cooldown:
     #   default-days: 7
 
-  - package-ecosystem: "pip"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    cooldown:
-      default-days: 7
-
-  - package-ecosystem: "uv"
+  - package-ecosystem: "pip" # TODO: consider "uv" instead
     directory: "/"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
use only pip, rather than both pip and uv
keep a comment suggesting we consider using uv instead in the future